### PR TITLE
Update existing build pipeline to only trigger on pull request

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -2,8 +2,6 @@ name: .Net 5 CI Build
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 
@@ -30,7 +28,7 @@ jobs:
       run: dotnet test --configuration Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
 
     - name: Copy Coverage To Predictable Location
-      run: ls coverage/**/ && cp -n coverage/**/coverage.cobertura.xml coverage/
+      run: cp -n coverage/**/coverage.cobertura.xml coverage/
 
     - name: Code Coverage Summary Report
       uses: irongut/CodeCoverageSummary@v1.0.5


### PR DESCRIPTION
In order to separate into several build pipelines (one for pull requests, and one for merging to master).

Hi, please make sure you have tested properly, and made sure any dependencies do not fail because of this change.