### PR TITLE
Set publish project explicitly in merge/deploy yml file

### DIFF
--- a/.github/workflows/merge-build.yml
+++ b/.github/workflows/merge-build.yml
@@ -1,4 +1,4 @@
-name: .Net 5 Merge build
+name: .Net 5 Merge and deploy
 
 on:
   workflow_dispatch:
@@ -30,7 +30,7 @@ jobs:
 
     - name: Publish
       run: |
-        dotnet publish -c Release -o app
+        dotnet publish src\API\API.csproj -c Release -o app
     
     - name: Deploy to Azure WebApp
       uses: azure/webapps-deploy@v2


### PR DESCRIPTION
Since IntegrationTests project also references web sdk, dotnet publish cannot distinguish between the API project, and the integration test project. This leads to a race condition which one get's published and bundled into the application.

Setting the project to publish explicitly circumvents this problem for now.